### PR TITLE
Add Claude with CAD project markdown

### DIFF
--- a/public/markdowns/projects/claude-with-cad.md
+++ b/public/markdowns/projects/claude-with-cad.md
@@ -1,0 +1,19 @@
+---
+id: claude-with-cad
+
+title: Claude with CAD
+
+description: 3d printing my prompt
+
+publish_date: "2026-04-22"
+
+---
+
+## Motivation
+I wanted to design a keychain that serves a practical purpose — reminding the owner where they've parked their car. The concept uses a miniature car as the knob and a gear shift mechanism to indicate the parking location. Rather than jumping straight into CAD software, I turned to Claude to brainstorm and iterate on the design.
+
+## Process
+Using Claude's brainstorming capabilities, I was able to rapidly explore different form factors, proportions and mechanical considerations for the keychain. Each iteration refined the design — from the shape of the car knob to the feel of the gear shift — before committing anything to a final model. This back-and-forth made it easy to think through potential issues early and arrive at a design worth printing.
+
+## Result
+Once the design was settled, I fed the final model to my 3D printer. The iterative prompting workflow meant fewer failed prints and less wasted filament. It's a good example of how conversational AI can fit naturally into a physical prototyping pipeline.


### PR DESCRIPTION
## Summary
- Adds a new project entry for "Claude with CAD" — a keychain designed through iterative brainstorming with Claude and fabricated on a 3D printer
- New markdown file at `public/markdowns/projects/claude-with-cad.md` with frontmatter and content

## Test plan
- [ ] Verify the project appears on the homepage project listing
- [ ] Verify `/projects/claude-with-cad` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)